### PR TITLE
utils: fix redundant redundancy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ default-members = ["crates/*"]
 authors = ["Eric Lagergren"]
 edition = "2021"
 license = "BSD-3-Clause"
-readme = "README.md"
 repository = "https://github.com/ericlagergren/sha3"
 
 [workspace.lints.rust]

--- a/crates/kmac/Cargo.toml
+++ b/crates/kmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3-kmac"
-version = "0.2.1"
+version = "0.2.2"
 description = """
 KMAC per NIST SP 800-185
 """

--- a/crates/kmac/Cargo.toml
+++ b/crates/kmac/Cargo.toml
@@ -7,7 +7,7 @@ KMAC per NIST SP 800-185
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 documentation = "https://docs.rs/sha3-kmac"
 keywords = [ "kmac", "mac", "sha3", "xof" ]

--- a/crates/kmac/Cargo.toml
+++ b/crates/kmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3-kmac"
-version = "0.2.2"
+version = "0.2.3"
 description = """
 KMAC per NIST SP 800-185
 """

--- a/crates/kmac/Cargo.toml
+++ b/crates/kmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3-kmac"
-version = "0.2.2"
+version = "0.2.1"
 description = """
 KMAC per NIST SP 800-185
 """

--- a/crates/kmac/README.md
+++ b/crates/kmac/README.md
@@ -8,7 +8,7 @@ KMAC per [NIST SP 800-185].
 
 ```bash
 [dependencies]
-sha3-kmac = "0.2.1"
+sha3-kmac = "0.2.2"
 ```
 
 ## Security

--- a/crates/kmac/README.md
+++ b/crates/kmac/README.md
@@ -8,7 +8,7 @@ KMAC per [NIST SP 800-185].
 
 ```bash
 [dependencies]
-sha3-kmac = "0.2.2"
+sha3-kmac = "0.2.3"
 ```
 
 ## Security

--- a/crates/tuple-hash/Cargo.toml
+++ b/crates/tuple-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuple-hash"
-version = "0.5.0"
+version = "0.5.1"
 description = """
 TupleHash per NIST SP 800-185
 """

--- a/crates/tuple-hash/Cargo.toml
+++ b/crates/tuple-hash/Cargo.toml
@@ -7,7 +7,7 @@ TupleHash per NIST SP 800-185
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 documentation = "https://docs.rs/tuple-hash"
 keywords = [ "tuple-hash", "hash", "sha3" ]

--- a/crates/tuple-hash/README.md
+++ b/crates/tuple-hash/README.md
@@ -8,7 +8,7 @@ TupleHash per [NIST SP 800-185].
 
 ```bash
 [dependencies]
-tuple-hash = "0.2"
+tuple-hash = "0.5.1"
 ```
 
 ## Security

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -39,7 +39,6 @@ typenum = { workspace = true, default-features = false, features = ["const-gener
 sha3-utils = { path = ".", features = ["std"] }
 
 [package.metadata.docs.rs]
-all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo-all-features]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -7,7 +7,7 @@ SHA-3 utilities
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 documentation = "https://docs.rs/sha3-utls"
 keywords = [ "sha3", "left_encode", "right_encode" ]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3-utils"
-version = "0.3.0"
+version = "0.3.1"
 description = """
 SHA-3 utilities
 """

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 [dependencies]
-sha3-utils = "0.2.1"
+sha3-utils = "0.3.1"
 ```
 
 ## Security

--- a/crates/utils/src/enc.rs
+++ b/crates/utils/src/enc.rs
@@ -10,7 +10,6 @@
 use core::{
     array, cmp, hint,
     iter::{ExactSizeIterator, FusedIterator},
-    mem::MaybeUninit,
 };
 
 #[cfg(feature = "no-panic")]
@@ -22,7 +21,7 @@ use typenum::{
     U2,
 };
 
-use super::util::{as_chunks, copy_from_slice, slice_assume_init_ref};
+use super::util::as_chunks;
 
 /// The size in bytes of [`usize`].
 const USIZE_BYTES: usize = ((usize::BITS + 7) / 8) as usize;
@@ -41,14 +40,17 @@ const _: () = assert!(USIZE_BYTES <= 255);
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub fn left_encode(mut x: usize) -> LeftEncode {
-    let mut buf = [0; 1 + USIZE_BYTES];
-
     // `x|1` ensures that `n < USIZE_BYTES`. It's cheaper than
     // using a conditional.
-    let n = ((x | 1).leading_zeros() / 8) as usize;
+    let n = (x | 1).leading_zeros() / 8;
+    // Shift into the leading zeros so that we write everything
+    // at the start of the buffer. This lets us use constants for
+    // writing, as well as lets us use fixed-size writes (see
+    // `bytepad_blocks`, etc.).
     x <<= n * 8;
 
-    buf[0] = (USIZE_BYTES - n) as u8;
+    let mut buf = [0; 1 + USIZE_BYTES];
+    buf[0] = (USIZE_BYTES - n as usize) as u8;
     buf[1..].copy_from_slice(&x.to_be_bytes());
 
     LeftEncode { buf }
@@ -64,7 +66,7 @@ pub struct LeftEncode {
 impl LeftEncode {
     /// Returns the number of encoded bytes.
     #[inline]
-    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless for this type")]
     pub const fn len(&self) -> usize {
         (self.buf[0] + 1) as usize
     }
@@ -122,13 +124,12 @@ impl PartialEq for LeftEncode {
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub fn left_encode_bytes(x: usize) -> LeftEncodeBytes {
-    let mut buf = [0; 1 + USIZE_BYTES + 1];
-
+    // Break `x*8` into double word arithmetic.
     let mut hi = (x >> (usize::BITS - 3)) as u8;
     let mut lo = x << 3;
 
     let n = if hi == 0 {
-        // `x|1` ensures that `n < USIZE_BYTES`. It's cheaper
+        // `lo|1` ensures that `n < USIZE_BYTES`. It's cheaper
         // than a conditional.
         let n = (lo | 1).leading_zeros() / 8;
         lo <<= n * 8;
@@ -139,9 +140,13 @@ pub fn left_encode_bytes(x: usize) -> LeftEncodeBytes {
         0
     };
 
-    buf[0] = (1 + USIZE_BYTES - n) as u8;
-    buf[1] = hi;
-    buf[2..2 + USIZE_BYTES].copy_from_slice(&lo.to_be_bytes());
+    // This might be a smidge better than assigning to `buf[0]`
+    // and `buf[1]` directly.
+    let v = ((1 + USIZE_BYTES - n) as u16) | ((hi as u16) << 8);
+
+    let mut buf = [0; 2 + USIZE_BYTES];
+    buf[..2].copy_from_slice(&v.to_le_bytes());
+    buf[2..].copy_from_slice(&lo.to_be_bytes());
 
     LeftEncodeBytes { buf }
 }
@@ -156,7 +161,7 @@ pub struct LeftEncodeBytes {
 impl LeftEncodeBytes {
     /// Returns the number of encoded bytes.
     #[inline]
-    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless for this type")]
     pub const fn len(&self) -> usize {
         (self.buf[0] + 1) as usize
     }
@@ -190,14 +195,14 @@ impl PartialEq for LeftEncodeBytes {
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub fn right_encode(x: usize) -> RightEncode {
-    let mut buf = [MaybeUninit::uninit(); USIZE_BYTES + 1];
-
-    copy_from_slice(&mut buf[..USIZE_BYTES], &x.to_be_bytes());
-
     // `x|1` ensures that `n < USIZE_BYTES`. It's cheaper than
     // using a conditional.
     let n = (x | 1).leading_zeros() / 8;
-    buf[buf.len() - 1].write((USIZE_BYTES - n as usize) as u8);
+
+    let mut buf = [0; USIZE_BYTES + 1];
+    buf[..USIZE_BYTES].copy_from_slice(&x.to_be_bytes());
+    buf[buf.len() - 1] = (USIZE_BYTES - n as usize) as u8;
+
     RightEncode { buf }
 }
 
@@ -205,18 +210,15 @@ pub fn right_encode(x: usize) -> RightEncode {
 #[derive(Copy, Clone, Debug)]
 pub struct RightEncode {
     // Invariant: `buf[buf.len()-1]` is in [1, buf.len()).
-    // Invariant: `buf[n..]` has been initialized where `n` is
-    // `buf.len() - 1 - buf[buf.len()-1]`.
-    buf: [MaybeUninit<u8>; USIZE_BYTES + 1],
+    buf: [u8; USIZE_BYTES + 1],
 }
 
 impl RightEncode {
     /// Returns the number of encoded bytes.
     #[inline]
-    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless for this type")]
     pub const fn len(&self) -> usize {
-        // SAFETY: `buf[buf.len()-1..]` has been initialized.
-        let n = unsafe { self.buf[self.buf.len() - 1].assume_init() };
+        let n = self.buf[self.buf.len() - 1];
         self.buf.len() - 1 - n as usize
     }
 
@@ -225,9 +227,7 @@ impl RightEncode {
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
         // SAFETY: `self.len()` is in [1, self.buf.len()).
-        let src = unsafe { self.buf.get_unchecked(self.len()..) };
-        // SAFETY: We initialized `src`.
-        unsafe { slice_assume_init_ref(src) }
+        unsafe { self.buf.get_unchecked(self.len()..) }
     }
 }
 
@@ -275,21 +275,23 @@ impl PartialEq for RightEncode {
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub fn right_encode_bytes(mut x: usize) -> RightEncodeBytes {
-    let mut buf = [MaybeUninit::uninit(); 1 + USIZE_BYTES + 1];
-
+    // Break `x*8` into double word arithmetic.
     let hi = (x >> (usize::BITS - 3)) & 0x7;
-    buf[0].write(hi as u8);
     x <<= 3;
-    copy_from_slice(&mut buf[1..1 + USIZE_BYTES], &x.to_be_bytes());
 
     // `x|1` ensures that `n < 8`. It's cheaper than the
     // obvious `if n == 8 { n = 7; }`.
     let n = if hi == 0 {
-        1 + ((x | 1).leading_zeros() / 8) as usize
+        1 + ((x | 1).leading_zeros() / 8)
     } else {
         0
     };
-    buf[buf.len() - 1].write((1 + USIZE_BYTES - n) as u8);
+
+    let mut buf = [0; 1 + USIZE_BYTES + 1];
+    buf[0] = hi as u8;
+    buf[1..1 + USIZE_BYTES].copy_from_slice(&x.to_be_bytes());
+    buf[1 + USIZE_BYTES] = (1 + USIZE_BYTES - n as usize) as u8;
+
     RightEncodeBytes { buf }
 }
 
@@ -297,18 +299,15 @@ pub fn right_encode_bytes(mut x: usize) -> RightEncodeBytes {
 #[derive(Copy, Clone, Debug)]
 pub struct RightEncodeBytes {
     // Invariant: `buf[buf.len()-1]` is in [1, buf.len()).
-    // Invariant: `buf[n..]` has been initialized where `n` is
-    // `buf.len() - 1 - buf[buf.len()-1]`.
-    buf: [MaybeUninit<u8>; 1 + USIZE_BYTES + 1],
+    buf: [u8; 1 + USIZE_BYTES + 1],
 }
 
 impl RightEncodeBytes {
     /// Returns the number of encoded bytes.
     #[inline]
-    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless for this type")]
     pub const fn len(&self) -> usize {
-        // SAFETY: `buf[buf.len()-1..]` has been initialized.
-        let n = unsafe { self.buf[self.buf.len() - 1].assume_init() };
+        let n = self.buf[self.buf.len() - 1];
         self.buf.len() - 1 - n as usize
     }
 
@@ -317,9 +316,7 @@ impl RightEncodeBytes {
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
         // SAFETY: `self.len()` is in [1, self.buf.len()).
-        let src = unsafe { self.buf.get_unchecked(self.len()..) };
-        // SAFETY: We initialized `src`.
-        unsafe { slice_assume_init_ref(src) }
+        unsafe { self.buf.get_unchecked(self.len()..) }
     }
 }
 

--- a/crates/utils/src/enc.rs
+++ b/crates/utils/src/enc.rs
@@ -51,27 +51,30 @@ pub fn left_encode(mut x: usize) -> LeftEncode {
     buf[0] = (USIZE_BYTES - n) as u8;
     buf[1..].copy_from_slice(&x.to_be_bytes());
 
-    LeftEncode {
-        buf,
-        n: (1 + USIZE_BYTES - n) as u8,
-    }
+    LeftEncode { buf }
 }
 
 /// The result of [`left_encode`].
 #[derive(Copy, Clone, Debug)]
 pub struct LeftEncode {
+    // Invariant: `buf[0]` is in [0, buf.len()-1).
     buf: [u8; 1 + USIZE_BYTES],
-    // Invariant: `n` is in [1, buf.len()).
-    n: u8,
 }
 
 impl LeftEncode {
+    /// Returns the number of encoded bytes.
+    #[inline]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    pub const fn len(&self) -> usize {
+        (self.buf[0] + 1) as usize
+    }
+
     /// Returns the encoded bytes.
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
-        // SAFETY: `n` is in [1, self.buf.len()).
-        unsafe { self.buf.get_unchecked(..self.n as usize) }
+        // SAFETY: `self.len()` is in [1, self.buf.len()).
+        unsafe { self.buf.get_unchecked(..self.len()) }
     }
 }
 
@@ -140,28 +143,30 @@ pub fn left_encode_bytes(x: usize) -> LeftEncodeBytes {
     buf[1] = hi;
     buf[2..2 + USIZE_BYTES].copy_from_slice(&lo.to_be_bytes());
 
-    LeftEncodeBytes {
-        buf,
-        n: (1 + 1 + USIZE_BYTES - n) as u8,
-    }
+    LeftEncodeBytes { buf }
 }
 
 /// The result of [`left_encode_bytes`].
 #[derive(Copy, Clone, Debug)]
 pub struct LeftEncodeBytes {
+    // Invariant: `buf[0]` is in [0, buf.len()-1).
     buf: [u8; 2 + USIZE_BYTES],
-    // Invariant: `buf[..n] has been initialized.
-    n: u8,
 }
 
 impl LeftEncodeBytes {
+    /// Returns the number of encoded bytes.
+    #[inline]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    pub const fn len(&self) -> usize {
+        (self.buf[0] + 1) as usize
+    }
+
     /// Returns the encoded bytes.
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
-        // SAFETY: We wrote to every element in
-        // `self.buf[..self.n]`.
-        unsafe { self.buf.get_unchecked(..self.n as usize) }
+        // SAFETY: `self.len()` is in [1, self.buf.len()).
+        unsafe { self.buf.get_unchecked(..self.len()) }
     }
 }
 
@@ -191,27 +196,36 @@ pub fn right_encode(x: usize) -> RightEncode {
 
     // `x|1` ensures that `n < USIZE_BYTES`. It's cheaper than
     // using a conditional.
-    let n = ((x | 1).leading_zeros() / 8) as usize;
-    buf[buf.len() - 1].write((USIZE_BYTES - n) as u8);
-    RightEncode { buf, n: n as u8 }
+    let n = (x | 1).leading_zeros() / 8;
+    buf[buf.len() - 1].write((USIZE_BYTES - n as usize) as u8);
+    RightEncode { buf }
 }
 
 /// The result of [`right_encode`].
 #[derive(Copy, Clone, Debug)]
 pub struct RightEncode {
+    // Invariant: `buf[buf.len()-1]` is in [1, buf.len()).
+    // Invariant: `buf[n..]` has been initialized where `n` is
+    // `buf.len() - 1 - buf[buf.len()-1]`.
     buf: [MaybeUninit<u8>; USIZE_BYTES + 1],
-    // Invariant: `n` is in [1, buf.len()).
-    // Invariant: `buf[n..]` has been initialized.
-    n: u8,
 }
 
 impl RightEncode {
+    /// Returns the number of encoded bytes.
+    #[inline]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    pub const fn len(&self) -> usize {
+        // SAFETY: `buf[buf.len()-1..]` has been initialized.
+        let n = unsafe { self.buf[self.buf.len() - 1].assume_init() };
+        self.buf.len() - 1 - n as usize
+    }
+
     /// Returns the encoded bytes.
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
-        // SAFETY: `n` is in [1, self.buf.len()).
-        let src = unsafe { self.buf.get_unchecked(self.n as usize..) };
+        // SAFETY: `self.len()` is in [1, self.buf.len()).
+        let src = unsafe { self.buf.get_unchecked(self.len()..) };
         // SAFETY: We initialized `src`.
         unsafe { slice_assume_init_ref(src) }
     }
@@ -276,25 +290,34 @@ pub fn right_encode_bytes(mut x: usize) -> RightEncodeBytes {
         0
     };
     buf[buf.len() - 1].write((1 + USIZE_BYTES - n) as u8);
-    RightEncodeBytes { buf, n: n as u8 }
+    RightEncodeBytes { buf }
 }
 
 /// The result of [`right_encode_bytes`].
 #[derive(Copy, Clone, Debug)]
 pub struct RightEncodeBytes {
+    // Invariant: `buf[buf.len()-1]` is in [1, buf.len()).
+    // Invariant: `buf[n..]` has been initialized where `n` is
+    // `buf.len() - 1 - buf[buf.len()-1]`.
     buf: [MaybeUninit<u8>; 1 + USIZE_BYTES + 1],
-    // Invariant: `n` is in [1, buf.len()).
-    // Invariant: `buf[n..]` has been initialized.
-    n: u8,
 }
 
 impl RightEncodeBytes {
+    /// Returns the number of encoded bytes.
+    #[inline]
+    #[allow(clippy::len_without_is_empty, reason = "Meaningless")]
+    pub const fn len(&self) -> usize {
+        // SAFETY: `buf[buf.len()-1..]` has been initialized.
+        let n = unsafe { self.buf[self.buf.len() - 1].assume_init() };
+        self.buf.len() - 1 - n as usize
+    }
+
     /// Returns the encoded bytes.
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic)]
     pub fn as_bytes(&self) -> &[u8] {
-        // SAFETY: `n` is in [1, self.buf.len()).
-        let src = unsafe { self.buf.get_unchecked(self.n as usize..) };
+        // SAFETY: `self.len()` is in [1, self.buf.len()).
+        let src = unsafe { self.buf.get_unchecked(self.len()..) };
         // SAFETY: We initialized `src`.
         unsafe { slice_assume_init_ref(src) }
     }
@@ -443,10 +466,10 @@ where
 
         let w = left_encode(W);
         first[..w.buf.len()].copy_from_slice(&w.buf);
-        i += w.n as usize;
+        i += w.len();
 
         first[i..i + s.prefix.buf.len()].copy_from_slice(&s.prefix.buf);
-        i += s.prefix.n as usize;
+        i += s.prefix.len();
 
         // Help the compiler out to avoid a bounds check.
         //

--- a/crates/utils/src/enc.rs
+++ b/crates/utils/src/enc.rs
@@ -142,7 +142,7 @@ pub fn left_encode_bytes(x: usize) -> LeftEncodeBytes {
 
     // This might be a smidge better than assigning to `buf[0]`
     // and `buf[1]` directly.
-    let v = ((1 + USIZE_BYTES - n) as u16) | ((hi as u16) << 8);
+    let v = ((1 + USIZE_BYTES - n) as u16) | ((u16::from(hi)) << 8);
 
     let mut buf = [0; 2 + USIZE_BYTES];
     buf[..2].copy_from_slice(&v.to_le_bytes());

--- a/crates/utils/src/util.rs
+++ b/crates/utils/src/util.rs
@@ -1,40 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::transmute_ptr_to_ptr)]
 
-use core::{
-    mem::{self, MaybeUninit},
-    slice,
-};
-
-// From https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.copy_from_slice
-pub(crate) fn copy_from_slice<'a, T>(dst: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
-where
-    T: Copy,
-{
-    // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
-    let uninit_src: &[MaybeUninit<T>] = unsafe { mem::transmute::<&[T], &[MaybeUninit<T>]>(src) };
-
-    dst.copy_from_slice(uninit_src);
-
-    // SAFETY: Valid elements have just been copied into `this` so it is initialized
-    unsafe { slice_assume_init_mut(dst) }
-}
-
-// From https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_mut
-unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
-    // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
-    // mutable reference which is also guaranteed to be valid for writes.
-    unsafe { &mut *(slice as *mut [MaybeUninit<T>] as *mut [T]) }
-}
-
-// From https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref
-pub(crate) unsafe fn slice_assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {
-    // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
-    // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
-    // The pointer obtained is valid since it refers to memory owned by `slice` which is a
-    // reference and thus guaranteed to be valid for reads.
-    unsafe { &*(slice as *const [MaybeUninit<T>] as *const [T]) }
-}
+use core::slice;
 
 // From https://doc.rust-lang.org/std/primitive.slice.html#method.as_chunks
 pub(crate) const fn as_chunks<T, const N: usize>(slice: &[T]) -> (&[[T; N]], &[T]) {


### PR DESCRIPTION
We don't need the `n` field since it's already encoded in the data itself. Oops.

Signed-off-by: Eric Lagergren <eric@ericlagergren.com>